### PR TITLE
Add survey results page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2398,8 +2398,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -4101,6 +4100,67 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
+    "d3-array": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.4.0.tgz",
+      "integrity": "sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw=="
+    },
+    "d3-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.0.tgz",
+      "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg=="
+    },
+    "d3-format": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.3.tgz",
+      "integrity": "sha512-mm/nE2Y9HgGyjP+rKIekeITVgBtX97o1nrvHCWX8F/yBYyevUTvu9vb5pUnKwrcSw7o7GuwMOWjS9gFDs4O+uQ=="
+    },
+    "d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-scale": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.1.tgz",
+      "integrity": "sha512-huz5byJO/6MPpz6Q8d4lg7GgSpTjIZW/l+1MQkzKfu2u8P6hjaXaStOpmyrD6ymKoW87d2QVFCKvSjLwjzx/rA==",
+      "requires": {
+        "d3-array": "1.2.0 - 2",
+        "d3-format": "1",
+        "d3-interpolate": "^1.2.0",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
+      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
     "damerau-levenshtein": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
@@ -4146,6 +4206,11 @@
         "decamelize": "^1.1.0",
         "map-obj": "^1.0.0"
       }
+    },
+    "decimal.js-light": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.0.tgz",
+      "integrity": "sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -9148,8 +9213,12 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -9398,6 +9467,11 @@
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
       "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
       "dev": true
+    },
+    "math-expression-evaluator": {
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.22.tgz",
+      "integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ=="
     },
     "math-random": {
       "version": "1.0.4",
@@ -10783,8 +10857,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.1",
@@ -12910,6 +12983,19 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "raf-schd": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.2.tgz",
+      "integrity": "sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ=="
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -13080,6 +13166,18 @@
         "react-is": "^16.9.0"
       }
     },
+    "react-resize-detector": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-4.2.1.tgz",
+      "integrity": "sha512-ZfPMBPxXi0o3xox42MIEtz84tPSVMW9GgwLHYvjVXlFM+OkNzbeEtpVSV+mSTJmk4Znwomolzt35zHN9LNBQMQ==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15",
+        "prop-types": "^15.7.2",
+        "raf-schd": "^4.0.2",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
     "react-router": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
@@ -13109,6 +13207,38 @@
         "react-router": "5.1.2",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-smooth": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-1.0.5.tgz",
+      "integrity": "sha512-eW057HT0lFgCKh8ilr0y2JaH2YbNcuEdFpxyg7Gf/qDKk9hqGMyXryZJ8iMGJEuKH0+wxS0ccSsBBB3W8yCn8w==",
+      "requires": {
+        "lodash": "~4.17.4",
+        "prop-types": "^15.6.0",
+        "raf": "^3.4.0",
+        "react-transition-group": "^2.5.0"
+      },
+      "dependencies": {
+        "dom-helpers": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        }
       }
     },
     "react-transition-group": {
@@ -13552,6 +13682,32 @@
         }
       }
     },
+    "recharts": {
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.0.0-beta.1.tgz",
+      "integrity": "sha512-awJH2DE6JRgp5ymzmH5dKh2Pu6prqZJCr3NRaYCcyub1fBa+fIG3ZlpLyl9hWizHPGEvfZLvcjIM+qgTsr9aSQ==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "core-js": "^3.4.2",
+        "d3-interpolate": "^1.3.0",
+        "d3-scale": "^3.1.0",
+        "d3-shape": "^1.3.5",
+        "lodash": "^4.17.5",
+        "prop-types": "^15.6.0",
+        "react-resize-detector": "^4.2.1",
+        "react-smooth": "^1.0.5",
+        "recharts-scale": "^0.4.2",
+        "reduce-css-calc": "^1.3.0"
+      }
+    },
+    "recharts-scale": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.3.tgz",
+      "integrity": "sha512-t8p5sccG9Blm7c1JQK/ak9O8o95WGhNXD7TXg/BW5bYbVlr6eCeRBNpgyigD4p6pSSMehC5nSvBUPj6F68rbFA==",
+      "requires": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -13571,6 +13727,31 @@
             "repeating": "^2.0.0"
           }
         }
+      }
+    },
+    "reduce-css-calc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "requires": {
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        }
+      }
+    },
+    "reduce-function-call": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.3.tgz",
+      "integrity": "sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==",
+      "requires": {
+        "balanced-match": "^1.0.0"
       }
     },
     "redux": {
@@ -13897,6 +14078,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
       "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^16.12.0",
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.1.2",
+    "recharts": "^2.0.0-beta.1",
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3",
     "reselect": "^4.0.0",

--- a/src/data/surveys.json
+++ b/src/data/surveys.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "fotw-2020-01-28",
+    "name": "Cherry"
+  },
+  {
+    "id": "fotw-2020-02-04",
+    "name": "Banana"
+  },
+  {
+    "id": "fotw-2020-02-11",
+    "name": "Bourbon"
+  }
+]

--- a/src/data/surveys.json
+++ b/src/data/surveys.json
@@ -1,14 +1,17 @@
 [
   {
     "id": "fotw-2020-01-28",
-    "name": "Cherry"
+    "name": "Cherry",
+    "visible": true
   },
   {
     "id": "fotw-2020-02-04",
-    "name": "Banana"
+    "name": "Banana",
+    "visible": true
   },
   {
     "id": "fotw-2020-02-11",
-    "name": "Bourbon"
+    "name": "Bourbon",
+    "visible": false
   }
 ]

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -8,9 +8,10 @@ export default class Home extends Component {
       <Container>
         <Row>
           <Col>
-            <h1>Welcome</h1>
+            <h1>Welcome to the DIY Mixing Poll!</h1>
             <p>
-              Help us by <Link to="/survey">taking the current survey</Link>!
+              You can <Link to="/survey">taking the current survey</Link> or{' '}
+              <Link to="/results">view completed survey results</Link>.
             </p>
           </Col>
         </Row>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -10,7 +10,7 @@ export default class Home extends Component {
           <Col>
             <h1>Welcome to the DIY Mixing Poll!</h1>
             <p>
-              You can <Link to="/survey">taking the current survey</Link> or{' '}
+              You can <Link to="/survey">take the current survey</Link> or{' '}
               <Link to="/results">view completed survey results</Link>.
             </p>
           </Col>

--- a/src/pages/Results.js
+++ b/src/pages/Results.js
@@ -13,6 +13,7 @@ import {
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
+import Surveys from 'data/surveys';
 import { actions as appActions } from 'reducers/application';
 import { getSurveys, getSelectedSurvey } from 'selectors/application';
 
@@ -79,6 +80,19 @@ export class Results extends Component {
   get selector() {
     const { surveys } = this.props;
 
+    const mappedSurveys = surveys.map(survey => {
+      const { surveyId } = survey;
+      const surveyMatch = Surveys.find(
+        innerSurvey => innerSurvey.id === surveyId
+      );
+
+      return (
+        <option value={surveyId} key={surveyId}>
+          {surveyMatch?.name || surveyId}
+        </option>
+      );
+    });
+
     return (
       <FormControl
         as="select"
@@ -87,11 +101,7 @@ export class Results extends Component {
         className="mb-2"
       >
         <option value="">Select a survey</option>
-        {surveys.map(survey => (
-          <option value={survey.surveyId} key={survey.surveyId}>
-            {survey.surveyId}
-          </option>
-        ))}
+        {mappedSurveys}
       </FormControl>
     );
   }

--- a/src/pages/Results.js
+++ b/src/pages/Results.js
@@ -1,17 +1,148 @@
-import React, { Component } from 'react';
-import { Container, Row, Col } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import React, { Component, PureComponent } from 'react';
+import { Container, Row, Col, FormControl } from 'react-bootstrap';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
-export default class Results extends Component {
+import { actions as appActions } from 'reducers/application';
+import { getSurveys, getSelectedSurvey } from 'selectors/application';
+
+class AngledTick extends PureComponent {
+  static propTypes = {
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+    payload: PropTypes.object.isRequired
+  };
+
+  render() {
+    const { x, y, payload } = this.props;
+
+    return (
+      <g transform={`translate(${x},${y})`}>
+        <text
+          x={0}
+          y={0}
+          dy={18}
+          textAnchor="end"
+          fill="#666"
+          transform="rotate(-35)"
+        >
+          {payload.value}
+        </text>
+      </g>
+    );
+  }
+}
+
+export class Results extends Component {
+  static propTypes = {
+    actions: PropTypes.shape({
+      loadSurveys: PropTypes.func.isRequired,
+      loadSurvey: PropTypes.func.isRequired
+    }).isRequired,
+    surveys: PropTypes.arrayOf(PropTypes.object),
+    selectedSurvey: PropTypes.object
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.handleSelectorChange = this.handleSelectorChange.bind(this);
+  }
+
+  componentDidMount() {
+    const { actions } = this.props;
+
+    actions.loadSurveys();
+  }
+
+  handleSelectorChange(event) {
+    const { actions } = this.props;
+    const {
+      target: { value }
+    } = event;
+
+    if (value) {
+      actions.loadSurvey(value);
+    }
+  }
+
+  get selector() {
+    const { surveys } = this.props;
+
+    return (
+      <FormControl
+        as="select"
+        defaultValue=""
+        onChange={this.handleSelectorChange}
+        className="mb-2"
+      >
+        <option value="">Select a survey</option>
+        {surveys.map(survey => (
+          <option value={survey.surveyId} key={survey.surveyId}>
+            {survey.surveyId}
+          </option>
+        ))}
+      </FormControl>
+    );
+  }
+
+  get chart() {
+    const { selectedSurvey } = this.props;
+
+    if (!selectedSurvey) {
+      return null;
+    }
+
+    return (
+      <ResponsiveContainer width="100%" height={500}>
+        <BarChart data={selectedSurvey.answers}>
+          <XAxis
+            dataKey="flavor"
+            tick={<AngledTick />}
+            height={100}
+            interval={0}
+          />
+          <YAxis allowDecimals={false} />
+          <Tooltip />
+          <CartesianGrid strokeDasharray="3 3" />
+          <Bar dataKey="count" fill="#4582ec" />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  }
+
   render() {
     return (
       <Container>
         <Row>
           <Col>
             <h1>Survey Results</h1>
-            <h3 className="text-muted">Coming Soon &trade;</h3>
+            {this.selector}
+            {this.chart}
           </Col>
         </Row>
       </Container>
     );
   }
 }
+
+export const mapStateToProps = state => ({
+  surveys: getSurveys(state),
+  selectedSurvey: getSelectedSurvey(state)
+});
+
+export const mapDispatchToProps = dispatch => ({
+  actions: bindActionCreators(appActions, dispatch)
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Results);

--- a/src/pages/Results.js
+++ b/src/pages/Results.js
@@ -86,6 +86,10 @@ export class Results extends Component {
         innerSurvey => innerSurvey.id === surveyId
       );
 
+      if (!surveyMatch || !surveyMatch.visible) {
+        return null;
+      }
+
       return (
         <option value={surveyId} key={surveyId}>
           {surveyMatch?.name || surveyId}

--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -1,6 +1,13 @@
 import { buildActions } from 'utils';
 
-export const types = buildActions('application', ['INIT_APP', 'SUBMIT_SURVEY']);
+export const types = buildActions('application', [
+  'INIT_APP',
+  'SUBMIT_SURVEY',
+  'LOAD_SURVEY',
+  'LOAD_SURVEY_SUCCESS',
+  'LOAD_SURVEYS',
+  'LOAD_SURVEYS_SUCCESS'
+]);
 
 const initApp = () => ({
   type: types.INIT_APP
@@ -12,15 +19,55 @@ const submitSurvey = (id, answers) => ({
   id
 });
 
+const loadSurvey = id => ({
+  type: types.LOAD_SURVEY,
+  id
+});
+
+const loadSurveySuccess = (id, answers) => ({
+  type: types.LOAD_SURVEY_SUCCESS,
+  id,
+  answers
+});
+
+const loadSurveys = () => ({
+  type: types.LOAD_SURVEYS
+});
+
+const loadSurveysSuccess = surveys => ({
+  type: types.LOAD_SURVEYS_SUCCESS,
+  surveys
+});
+
 export const actions = {
   initApp,
+  loadSurvey,
+  loadSurveys,
+  loadSurveysSuccess,
+  loadSurveySuccess,
   submitSurvey
 };
 
-export const initialState = {};
+export const initialState = {
+  surveys: [],
+  selectedSurvey: null
+};
 
 export const reducer = (state = initialState, action = {}) => {
   switch (action.type) {
+    case types.LOAD_SURVEY_SUCCESS:
+      return {
+        ...state,
+        selectedSurvey: {
+          id: action.id,
+          answers: action.answers
+        }
+      };
+    case types.LOAD_SURVEYS_SUCCESS:
+      return {
+        ...state,
+        surveys: action.surveys
+      };
     default:
       return state;
   }

--- a/src/sagas/application.js
+++ b/src/sagas/application.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
-import { all, call, takeLatest } from 'redux-saga/effects';
+import { all, call, takeLatest, put } from 'redux-saga/effects';
 
-import { types } from 'reducers/application';
+import { actions, types } from 'reducers/application';
 
 function* submitSurveyWorker({ answers, id }) {
   try {
@@ -15,15 +15,76 @@ function* submitSurveyWorker({ answers, id }) {
   }
 }
 
+function* loadSurveyWorker({ id }) {
+  try {
+    const { status, data } = yield call(axios.get, `${API_URL}/survey/${id}`);
+
+    if (status !== 200) {
+      throw new Error(`Failed to fetch data for survey ${id}`);
+    }
+
+    const counts = {};
+
+    for (const { favoriteFlavor } of data) {
+      if (!counts[favoriteFlavor]) {
+        counts[favoriteFlavor] = 0;
+      }
+
+      counts[favoriteFlavor]++;
+    }
+
+    const countArray = Object.entries(counts).map(([flavor, count]) => ({
+      flavor,
+      count
+    }));
+
+    countArray.sort((a, b) => (a.count < b.count ? 1 : -1));
+
+    yield put(actions.loadSurveySuccess(id, countArray));
+  } catch (error) {
+    // eslint-disable-next-line
+    console.error(error);
+  }
+}
+
+function* loadSurveysWorker() {
+  try {
+    const { status, data } = yield call(axios.get, `${API_URL}/surveys`);
+
+    if (status !== 200) {
+      throw new Error(`Failed to fetch survey list`);
+    }
+
+    data.sort((a, b) => b.surveyId.localeCompare(a.surveyId));
+
+    yield put(actions.loadSurveysSuccess(data));
+  } catch (error) {
+    // eslint-disable-next-line
+    console.error(error);
+  }
+}
+
 export const workers = {
+  loadSurveyWorker,
+  loadSurveysWorker,
   submitSurveyWorker
 };
+
+function* loadSurveyWatcher() {
+  yield takeLatest(types.LOAD_SURVEY, loadSurveyWorker);
+}
+
+function* loadSurveysWatcher() {
+  yield takeLatest(types.LOAD_SURVEYS, loadSurveysWorker);
+}
 
 function* submitSurveyWatcher() {
   yield takeLatest(types.SUBMIT_SURVEY, submitSurveyWorker);
 }
 
 export const watchers = {
+  loadSurveyWatcher,
+  loadSurveysWatcher,
   submitSurveyWatcher
 };
 

--- a/src/selectors/application.js
+++ b/src/selectors/application.js
@@ -1,1 +1,13 @@
+import { createSelector } from 'reselect';
+
 export const getApplication = state => state.application;
+
+export const getSurveys = createSelector(
+  getApplication,
+  application => application.surveys
+);
+
+export const getSelectedSurvey = createSelector(
+  getApplication,
+  application => application.selectedSurvey
+);


### PR DESCRIPTION
This PR adds [recharts](https://recharts.org/) and integrates with new routes in the API that allow a web user to browse survey results for completed surveys.

![thing](https://user-images.githubusercontent.com/266545/74208674-8e7ff080-4c52-11ea-88ce-1242713f0565.PNG)

* [Added](https://github.com/diy-ejuice/diy-poll-web/compare/feature/search-results?expand=1#diff-f6cb072a2ff09f237d6c3f88e240c721) a JSON metadata file that whitelists/blacklists surveys as visible or invisible and provides a "friendly" name mapping
* [Overhaul](https://github.com/diy-ejuice/diy-poll-web/compare/feature/search-results?expand=1#diff-b020c422a681759b7b7032851a4e91dbR47) the results component to implement recharts
* [Add](https://github.com/diy-ejuice/diy-poll-web/compare/feature/search-results?expand=1#diff-bb7a6a61e449a99e756724ffa2c8c109R6-R9) redux actions for survey list load and survey results load
* [Add](https://github.com/diy-ejuice/diy-poll-web/compare/feature/search-results?expand=1#diff-bb7a6a61e449a99e756724ffa2c8c109R58) state persistence for survey data
* [Add](https://github.com/diy-ejuice/diy-poll-web/compare/feature/search-results?expand=1#diff-d25ba671e0b49dde38d045baa368a1e5R18) sagas to fetch survey data from API
* [Add](https://github.com/diy-ejuice/diy-poll-web/compare/feature/search-results?expand=1#diff-c561400e3720be1a9b2fea5e84ff802fR5) selectors for new redux state
* [Update](https://github.com/diy-ejuice/diy-poll-web/pull/4/files#diff-322de0557ebc24da35372e3400a46b65R11) home page content with new link