### PR TITLE
Support multi-question surveys on results page

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,24 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "usage",
+        "corejs": 3
+      }
+    ],
+    "@babel/preset-react"
+  ],
   "plugins": [
+    "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-object-rest-spread",
-    "@babel/plugin-transform-runtime",
+    [
+      "@babel/plugin-transform-runtime",
+      {
+        "corejs": 3
+      }
+    ],
     "@babel/plugin-transform-regenerator"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -957,10 +957,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.3.tgz",
-      "integrity": "sha512-lrIU4aVbmlM/wQPzhEvzvNJskKyYptuXb0fGC0lTQTupTOYtR2Vqbu6/jf8vTr4M8Wt1nIzxVrSvPI5qESa/xA==",
-      "dev": true,
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz",
+      "integrity": "sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==",
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.2"
@@ -3731,8 +3730,7 @@
     "core-js-pure": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
-      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==",
-      "dev": true
+      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "cross-env NODE_ENV=development webpack-dev-server"
   },
   "dependencies": {
-    "@babel/runtime": "^7.8.3",
+    "@babel/runtime-corejs3": "^7.8.4",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-brands-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
@@ -30,6 +30,7 @@
     "recharts": "^2.0.0-beta.1",
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3",
+    "regenerator-runtime": "^0.13.3",
     "reselect": "^4.0.0",
     "survey-react": "^1.5.1"
   },
@@ -37,6 +38,7 @@
     "@babel/core": "^7.8.3",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-regenerator": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.3",

--- a/src/components/AngledTick/AngledTick.js
+++ b/src/components/AngledTick/AngledTick.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+
+export default class AngledTick extends PureComponent {
+  static propTypes = {
+    x: PropTypes.number,
+    y: PropTypes.number,
+    payload: PropTypes.object
+  };
+
+  static defaultProps = {
+    x: 0,
+    y: 0,
+    payload: {}
+  };
+
+  render() {
+    const { x, y, payload } = this.props;
+
+    return (
+      <g transform={`translate(${x},${y})`}>
+        <text
+          x={0}
+          y={0}
+          dy={18}
+          textAnchor="end"
+          fill="#666"
+          transform="rotate(-35)"
+          fontSize={14}
+        >
+          {payload.value}
+        </text>
+      </g>
+    );
+  }
+}

--- a/src/pages/Results.js
+++ b/src/pages/Results.js
@@ -31,7 +31,16 @@ export class Results extends Component {
   constructor(props) {
     super(props);
 
-    this.handleSelectorChange = this.handleSelectorChange.bind(this);
+    this.state = {
+      selectedQuestion: '',
+      questions: []
+    };
+    this.handleSurveySelectorChange = this.handleSurveySelectorChange.bind(
+      this
+    );
+    this.handleQuestionSelectorChange = this.handleQuestionSelectorChange.bind(
+      this
+    );
   }
 
   componentDidMount() {
@@ -40,18 +49,48 @@ export class Results extends Component {
     actions.loadSurveys();
   }
 
-  handleSelectorChange(event) {
+  async handleSurveySelectorChange(event) {
     const { actions } = this.props;
     const {
       target: { value }
     } = event;
 
-    if (value) {
-      actions.loadSurvey(value);
+    if (!value) {
+      return;
     }
+
+    actions.loadSurvey(value);
+
+    const { default: jsonData } = await import(`data/${value}.json`);
+
+    if (!jsonData?.pages?.length) {
+      return;
+    }
+
+    const questions = jsonData.pages[0].elements.map(element => ({
+      id: element.name,
+      name: element.title
+    }));
+
+    this.setState({
+      questions,
+      selectedQuestion: questions.length ? questions[0].id : ''
+    });
   }
 
-  get selector() {
+  handleQuestionSelectorChange(event) {
+    const {
+      target: { value }
+    } = event;
+
+    if (!value) {
+      return;
+    }
+
+    this.setState({ selectedQuestion: value });
+  }
+
+  get surveySelector() {
     const { surveys } = this.props;
 
     const mappedSurveys = surveys.map(survey => {
@@ -75,7 +114,7 @@ export class Results extends Component {
       <FormControl
         as="select"
         defaultValue=""
-        onChange={this.handleSelectorChange}
+        onChange={this.handleSurveySelectorChange}
         className="mb-2"
       >
         <option value="">Select a survey</option>
@@ -84,7 +123,8 @@ export class Results extends Component {
     );
   }
 
-  get chart() {
+  get questionSelector() {
+    const { questions, selectedQuestion } = this.state;
     const { selectedSurvey } = this.props;
 
     if (!selectedSurvey) {
@@ -92,8 +132,32 @@ export class Results extends Component {
     }
 
     return (
+      <FormControl
+        as="select"
+        value={selectedQuestion}
+        onChange={this.handleQuestionSelectorChange}
+        className="mb-2"
+      >
+        {questions.map(question => (
+          <option value={question.id} key={question.id}>
+            {question.name}
+          </option>
+        ))}
+      </FormControl>
+    );
+  }
+
+  get chart() {
+    const { selectedQuestion } = this.state;
+    const { selectedSurvey } = this.props;
+
+    if (!selectedSurvey || !selectedQuestion) {
+      return null;
+    }
+
+    return (
       <ResponsiveContainer width="100%" height={500}>
-        <BarChart data={selectedSurvey.answers}>
+        <BarChart data={selectedSurvey.answers[selectedQuestion]}>
           <XAxis
             dataKey="flavor"
             tick={<AngledTick />}
@@ -102,7 +166,7 @@ export class Results extends Component {
           />
           <YAxis allowDecimals={false} />
           <Tooltip />
-          <CartesianGrid strokeDasharray="3 3" />
+          <CartesianGrid strokeDasharray="2 4" />
           <Bar dataKey="count" fill="#4582ec" />
         </BarChart>
       </ResponsiveContainer>
@@ -115,7 +179,8 @@ export class Results extends Component {
         <Row>
           <Col>
             <h1>Survey Results</h1>
-            {this.selector}
+            {this.surveySelector}
+            {this.questionSelector}
             {this.chart}
           </Col>
         </Row>

--- a/src/pages/Results.js
+++ b/src/pages/Results.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component, PureComponent } from 'react';
+import React, { Component } from 'react';
 import { Container, Row, Col, FormControl } from 'react-bootstrap';
 import {
   Bar,
@@ -13,36 +13,10 @@ import {
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
+import AngledTick from 'components/AngledTick/AngledTick';
 import Surveys from 'data/surveys';
 import { actions as appActions } from 'reducers/application';
 import { getSurveys, getSelectedSurvey } from 'selectors/application';
-
-class AngledTick extends PureComponent {
-  static propTypes = {
-    x: PropTypes.number.isRequired,
-    y: PropTypes.number.isRequired,
-    payload: PropTypes.object.isRequired
-  };
-
-  render() {
-    const { x, y, payload } = this.props;
-
-    return (
-      <g transform={`translate(${x},${y})`}>
-        <text
-          x={0}
-          y={0}
-          dy={18}
-          textAnchor="end"
-          fill="#666"
-          transform="rotate(-35)"
-        >
-          {payload.value}
-        </text>
-      </g>
-    );
-  }
-}
 
 export class Results extends Component {
   static propTypes = {

--- a/src/pages/Results.js
+++ b/src/pages/Results.js
@@ -139,7 +139,7 @@ export class Results extends Component {
         className="mb-2"
       >
         {questions.map(question => (
-          <option value={question.id} key={question.id}>
+          <option value={question.id} key={question.name}>
             {question.name}
           </option>
         ))}


### PR DESCRIPTION
This PR adds a separate dropdown to the results page which lets you select the survey question you want to view answers for after selecting a survey to view. The data was there already on the API side, but it requires a different mapping/translation strategy in the saga. It also needs toolchain updates to support dynamically importing the survey JSON from the source tree.

![questions](https://user-images.githubusercontent.com/266545/74255168-7b573a00-4cbf-11ea-82f8-50a8b970fa3c.PNG)
