### PR TITLE
Add document titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13127,6 +13127,22 @@
         "scheduler": "^0.18.0"
       }
     },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "react-helmet": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.1.tgz",
+      "integrity": "sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.5.4",
+        "react-fast-compare": "^2.0.2",
+        "react-side-effect": "^1.1.0"
+      }
+    },
     "react-is": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
@@ -13205,6 +13221,14 @@
         "react-router": "5.1.2",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-side-effect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.2.0.tgz",
+      "integrity": "sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==",
+      "requires": {
+        "shallowequal": "^1.0.1"
       }
     },
     "react-smooth": {
@@ -14591,6 +14615,11 @@
           "dev": true
         }
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^16.12.0",
     "react-bootstrap": "^1.0.0-beta.16",
     "react-dom": "^16.12.0",
+    "react-helmet": "^5.2.1",
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.1.2",
     "recharts": "^2.0.0-beta.1",

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -14,7 +14,7 @@ export default class Header extends Component {
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="mr-auto">
             <Nav.Link as={Link} to="/survey">
-              Take Survey
+              Current Poll
             </Nav.Link>
             <Nav.Link as={Link} to="/results">
               View Results

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,11 +1,13 @@
 import React, { Component } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
+import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 
 export default class Home extends Component {
   render() {
     return (
       <Container>
+        <Helmet title="DIY Mixing Poll" />
         <Row>
           <Col>
             <h1>Welcome to the DIY Mixing Poll!</h1>

--- a/src/pages/Results.js
+++ b/src/pages/Results.js
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Container, Row, Col, FormControl, Spinner } from 'react-bootstrap';
+import { Helmet } from 'react-helmet';
+import { connect } from 'react-redux';
 import {
   Bar,
   BarChart,
@@ -10,7 +12,6 @@ import {
   XAxis,
   YAxis
 } from 'recharts';
-import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import AngledTick from 'components/AngledTick/AngledTick';
@@ -185,9 +186,10 @@ export class Results extends Component {
   render() {
     return (
       <Container>
+        <Helmet title="Survey Results" />
         <Row>
           <Col>
-            <h1>Survey Results</h1>
+            <h1>Poll Results</h1>
             {this.surveySelector}
             {this.questionSelector}
             {this.chart}

--- a/src/pages/Survey.js
+++ b/src/pages/Survey.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
+import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as Survey from 'survey-react';
@@ -49,9 +50,10 @@ export class SurveyPage extends Component {
   render() {
     return (
       <Container>
+        <Helmet title="Current Poll" />
         <Row>
           <Col>
-            <h1>Take Survey</h1>
+            <h1>Current Poll</h1>
             <Survey.Survey
               css={this.css}
               model={this.model}


### PR DESCRIPTION
This PR uses [react-helmet](https://github.com/nfl/react-helmet) to set the document `<title>` so that web browsers don't just display the URL as the tab title.

Also, change a few references to "survey" to "poll."