### PR TITLE
Fix polls with no responses not appearing on Survey page

### DIFF
--- a/src/components/SurveySelector/SurveySelector.js
+++ b/src/components/SurveySelector/SurveySelector.js
@@ -3,40 +3,17 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { FormControl, Col, Spinner } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import Surveys from 'data/surveys';
-import { actions as appActions } from 'reducers/application';
 import { getSelectedSurvey, getSurveys } from 'selectors/application';
 
 export class SurveySelector extends Component {
   static propTypes = {
-    actions: PropTypes.shape({
-      loadSurvey: PropTypes.func.isRequired
-    }).isRequired,
+    onChange: PropTypes.func,
     showVisible: PropTypes.bool.isRequired,
     selectedSurvey: PropTypes.object,
     surveys: PropTypes.arrayOf(PropTypes.object)
   };
-
-  constructor(props) {
-    super(props);
-
-    this.handleSurveyChange = this.handleSurveyChange.bind(this);
-  }
-
-  handleSurveyChange(event) {
-    const { actions } = this.props;
-    const {
-      target: { value }
-    } = event;
-
-    if (!value) {
-      return;
-    }
-
-    actions.loadSurvey(value);
-  }
 
   get surveysLoading() {
     return (
@@ -50,32 +27,27 @@ export class SurveySelector extends Component {
   get options() {
     const { showVisible } = this.props;
 
-    return this.props.surveys.map(survey => {
-      const { surveyId } = survey;
-      const surveyMatch = Surveys.find(
-        innerSurvey => innerSurvey.id === surveyId
-      );
-
-      if (!surveyMatch || surveyMatch.visible !== showVisible) {
+    return Surveys.map(survey => {
+      if (survey.visible !== showVisible) {
         return null;
       }
 
       // use the last ten characters of the id as the date
       const surveyDate = format(
-        startOfWeek(parseISO(surveyId.substr(-10))),
+        startOfWeek(parseISO(survey.id.substr(-10))),
         'MMM do'
       );
 
       return (
-        <option value={surveyId} key={surveyId}>
-          {surveyMatch.name || surveyId} - Week of {surveyDate}
+        <option value={survey.id} key={survey.id}>
+          {survey.name || survey.id} - Week of {surveyDate}
         </option>
       );
     });
   }
 
   render() {
-    const { surveys, selectedSurvey } = this.props;
+    const { onChange, surveys, selectedSurvey } = this.props;
 
     if (!Array.isArray(surveys) || !surveys.length) {
       return this.surveysLoading;
@@ -85,7 +57,7 @@ export class SurveySelector extends Component {
       <FormControl
         as="select"
         defaultValue={selectedSurvey?.id}
-        onChange={this.handleSurveyChange}
+        onChange={onChange}
         className="mb-2"
       >
         <option value="">Select a survey</option>
@@ -100,8 +72,4 @@ export const mapStateToProps = state => ({
   selectedSurvey: getSelectedSurvey(state)
 });
 
-export const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators(appActions, dispatch)
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(SurveySelector);
+export default connect(mapStateToProps, null)(SurveySelector);

--- a/src/pages/Results.js
+++ b/src/pages/Results.js
@@ -37,6 +37,7 @@ export class Results extends Component {
       selectedQuestion: '',
       questions: []
     };
+    this.handleSurveyChange = this.handleSurveyChange.bind(this);
     this.handleQuestionChange = this.handleQuestionChange.bind(this);
 
     if (props.match) {
@@ -79,6 +80,19 @@ export class Results extends Component {
         return;
       }
     }
+  }
+
+  handleSurveyChange(event) {
+    const { actions } = this.props;
+    const {
+      target: { value }
+    } = event;
+
+    if (!value) {
+      return;
+    }
+
+    actions.loadSurvey(value);
   }
 
   handleQuestionChange(event) {
@@ -150,7 +164,10 @@ export class Results extends Component {
         <Row>
           <Col>
             <h1>Poll Results</h1>
-            <SurveySelector showVisible={true} />
+            <SurveySelector
+              showVisible={true}
+              onChange={this.handleSurveyChange}
+            />
             {this.questionSelector}
             {this.chart}
           </Col>

--- a/src/pages/Survey.js
+++ b/src/pages/Survey.js
@@ -14,6 +14,7 @@ import { getSelectedSurvey, getSurveys } from 'selectors/application';
 export class SurveyPage extends Component {
   static propTypes = {
     actions: PropTypes.shape({
+      selectSurvey: PropTypes.func.isRequired,
       submitSurvey: PropTypes.func.isRequired,
       loadSurvey: PropTypes.func.isRequired,
       loadSurveys: PropTypes.func.isRequired
@@ -39,6 +40,7 @@ export class SurveyPage extends Component {
     };
     this.surveys = [];
     this.onComplete = this.onComplete.bind(this);
+    this.handleSurveyChange = this.handleSurveyChange.bind(this);
   }
 
   async componentDidMount() {
@@ -51,6 +53,19 @@ export class SurveyPage extends Component {
     );
 
     actions.loadSurveys();
+  }
+
+  handleSurveyChange(event) {
+    const { actions } = this.props;
+    const {
+      target: { value }
+    } = event;
+
+    if (!value) {
+      return;
+    }
+
+    actions.selectSurvey(value);
   }
 
   onComplete(model) {
@@ -95,7 +110,10 @@ export class SurveyPage extends Component {
         <Row>
           <Col>
             <h1>Active Polls</h1>
-            <SurveySelector showVisible={false} />
+            <SurveySelector
+              showVisible={false}
+              onChange={this.handleSurveyChange}
+            />
             {this.survey}
           </Col>
         </Row>

--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -2,11 +2,12 @@ import { buildActions } from 'utils';
 
 export const types = buildActions('application', [
   'INIT_APP',
-  'SUBMIT_SURVEY',
-  'LOAD_SURVEY',
   'LOAD_SURVEY_SUCCESS',
+  'LOAD_SURVEY',
+  'LOAD_SURVEYS_SUCCESS',
   'LOAD_SURVEYS',
-  'LOAD_SURVEYS_SUCCESS'
+  'SELECT_SURVEY',
+  'SUBMIT_SURVEY'
 ]);
 
 const initApp = () => ({
@@ -16,6 +17,11 @@ const initApp = () => ({
 const submitSurvey = (id, answers) => ({
   type: types.SUBMIT_SURVEY,
   answers,
+  id
+});
+
+const selectSurvey = id => ({
+  type: types.SELECT_SURVEY,
   id
 });
 
@@ -45,6 +51,7 @@ export const actions = {
   loadSurveys,
   loadSurveysSuccess,
   loadSurveySuccess,
+  selectSurvey,
   submitSurvey
 };
 
@@ -55,6 +62,14 @@ export const initialState = {
 
 export const reducer = (state = initialState, action = {}) => {
   switch (action.type) {
+    case types.SELECT_SURVEY:
+      return {
+        ...state,
+        selectedSurvey: {
+          id: action.id,
+          answers: []
+        }
+      };
     case types.LOAD_SURVEY_SUCCESS:
       return {
         ...state,


### PR DESCRIPTION
This PR breaks up the shared onChange logic for SurveySelector so that it handles the change event differently on each page - on the Survey page it now calls a new `selectSurvey` action which only sets the selected survey ID and does not request it from the server. The Results page keeps its existing behavior.

I also [fixed](https://github.com/diy-ejuice/diy-poll-web/compare/master...fix/empty-polls#diff-4ac6db783cda90804915066eae179547L53) an issue where polls that had no votes would not be shown in the SurveySelector on the Survey page.